### PR TITLE
Add support for !executable YAML tag

### DIFF
--- a/src/cloudabi-run/cloudabi-run.1
+++ b/src/cloudabi-run/cloudabi-run.1
@@ -1,4 +1,4 @@
-.\" Copyright (c) 2015-2017 Nuxi, https://nuxi.nl/
+.\" Copyright (c) 2015-2018 Nuxi, https://nuxi.nl/
 .\" All rights reserved.
 .\"
 .\" Redistribution and use in source and binary forms, with or without
@@ -21,7 +21,7 @@
 .\" LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
-.Dd August 29, 2017
+.Dd January 13, 2018
 .Dt CLOUDABI-RUN 1
 .Os
 .Sh NAME
@@ -110,6 +110,14 @@ or the special values
 .Dq Li stdout
 and
 .Dq Li stderr .
+.It Cm "tag:nuxi.nl,2015:cloudabi/executable"
+Provides a file descriptor of the target executable
+.Ar path ,
+opened
+.Dv O_EXEC
+if possible,
+.Dv O_RDONLY
+otherwise.
 .It Cm "tag:nuxi.nl,2015:cloudabi/file: map"
 Opens a file for reading.
 File objects have the following attributes:

--- a/src/cloudabi-run/yaml_file_descriptor_factory.cc
+++ b/src/cloudabi-run/yaml_file_descriptor_factory.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Nuxi, https://nuxi.nl/
+// Copyright (c) 2017-2018 Nuxi, https://nuxi.nl/
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -55,6 +55,8 @@ const argdata_t *YAMLFileDescriptorFactory::GetScalar(const YAML::Mark &mark,
       throw YAML::ParserException(mark, "XXX!");
     }
     return argdatas_.emplace_back(argdata_t::create_fd(fd)).get();
+  } else if (tag == "tag:nuxi.nl,2015:cloudabi/executable") {
+    return argdatas_.emplace_back(argdata_t::create_fd(execfd_)).get();
   } else {
     return fallback_->GetScalar(mark, tag, value);
   }

--- a/src/cloudabi-run/yaml_file_descriptor_factory.h
+++ b/src/cloudabi-run/yaml_file_descriptor_factory.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Nuxi, https://nuxi.nl/
+// Copyright (c) 2017-2018 Nuxi, https://nuxi.nl/
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -18,8 +18,8 @@ namespace cloudabi_run {
 class YAMLFileDescriptorFactory
     : public yaml2argdata::YAMLFactory<const argdata_t *> {
  public:
-  YAMLFileDescriptorFactory(YAMLFactory<const argdata_t *> *fallback)
-      : fallback_(fallback) {
+  YAMLFileDescriptorFactory(YAMLFactory<const argdata_t *> *fallback, int execfd)
+      : fallback_(fallback), execfd_(execfd) {
   }
 
   const argdata_t *GetNull(const YAML::Mark &mark) override;
@@ -34,6 +34,7 @@ class YAMLFileDescriptorFactory
 
  private:
   YAMLFactory<const argdata_t *> *const fallback_;
+  const int execfd_;
 
   std::vector<std::unique_ptr<argdata_t>> argdatas_;
   std::vector<std::shared_ptr<arpc::FileDescriptor>> fds_;


### PR DESCRIPTION
Per discussion on IRC: Introduce an !executable tag that will provide
a file descriptor of the target executable (opened O_EXEC if avaiable,
O_RDONLY otherweise).

This is primarily to ease porting of legacy applications that need to
execute themselves, now that we lack fork.