### PR TITLE
[libemulator] Fix a call to free with an invalid pointer.

### DIFF
--- a/src/libemulator/posix.c
+++ b/src/libemulator/posix.c
@@ -1363,7 +1363,7 @@ static cloudabi_errno_t path_get(struct path_access *pa, cloudabi_lookup_t fd,
 
       // Finished expanding symlink. Continue processing along the
       // original path.
-      free(paths[curpath--]);
+      free(paths_start[curpath--]);
     }
     continue;
 


### PR DESCRIPTION
The code maintains `paths_start` pointers for the purpose of holding onto the pointers that need to be freed, but missed using them in one place. This fixes it.